### PR TITLE
fix(demojify): Do not remove U+0023 # Number Sign

### DIFF
--- a/Demojify.lua
+++ b/Demojify.lua
@@ -104,7 +104,6 @@ local blockedSingles = lookupify {
 	0x00023F8,
 	0x00023F9,
 	0x00023FA,
-	0x0000023,
 	0x0001F51F,
 	-- unicode 8
 	0x0001F6CC,


### PR DESCRIPTION
👋 I noticed that the # number symbol is being removed as if it is an emoji.

See https://github.com/kdheepak/panvimdoc/pull/50 for additional information around the issue.

Please let me know what you think. Also, I noticed there isn't much activity of late, is this repo still maintained? Thanks!